### PR TITLE
Fix beer regex

### DIFF
--- a/lib/listeners/beer.js
+++ b/lib/listeners/beer.js
@@ -14,7 +14,7 @@ var beer = module.exports = function () {
   self.preferences = self.config.get('karma:preferences') || {};
 
   self.on('*::gotMessage', function (data) {
-    var re = /(\w+)((:|,) )?(\+\+|--)/,
+    var re = /^(\w+)((:|,) )?(\+\+|--)/,
         res;
 
     if (res = re.exec(data.text)) {


### PR DESCRIPTION
Not doing that results in matching messages like 'my g++ fails to compile node' (g gets karma then).
