### PR TITLE
Fix GH regex

### DIFF
--- a/lib/plugins/gh.js
+++ b/lib/plugins/gh.js
@@ -12,10 +12,10 @@ gh.gh = function (data, command) {
   if (!command[1]) {
     return;
   }
-  var user    = /([a-zA-Z0-9_-]+)/,
-      project = /([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]+)/,
-      issue   = /([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]+)#([0-9]+)/,
-      SHA     = /([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]+)@([a-fA-F0-9]+)/,
+  var user    = /([\w\.-]+)/,
+      project = /([\w\.-]+)\/([\w\.-]+)/,
+      issue   = /([\w\.-]+)\/([\w\.-]+)#(\d+)/,
+      SHA     = /([\w\.-]+)\/([\w\.-]+)@([a-fA-F0-9]+)/,
       result;
 
   if (result = issue.exec(command[1])) {


### PR DESCRIPTION
GitHub plugin didn't match a dot, so matching, for example, `hook.io` wasn't possible.
